### PR TITLE
Solve shared buffer in entities node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## node-red-contrib-letsfiware-NGSI v0.4.2
+
+- Fix shared buffer in entities node (#30)
+
 ## node-red-contrib-letsfiware-NGSI v0.4.0-next
 
 -   Update copyright date (#28)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ngsi-ld",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Node-RED implementation for NGSI-LD",
   "scripts": {
     "lint": "./node_modules/eslint/bin/eslint.js --ext .json,.js src test",

--- a/src/nodes/NGSI-LD/entities/entities.js
+++ b/src/nodes/NGSI-LD/entities/entities.js
@@ -79,29 +79,6 @@ const getEntities = async function (msg, param) {
   param.buffer.close();
 };
 
-const nobuffering = {
-  node: null,
-  msg: null,
-  open: function (node, msg) {
-    this.node = node;
-    this.msg = msg;
-    return this;
-  },
-  send: function (entities) {
-    const message = Object.assign({}, this.msg);
-    message.payload = entities;
-    message.statusCode = 200;
-    this.node.send(message);
-  },
-  close: function () {},
-  out: function (entities) {
-    const message = Object.assign({}, this.msg);
-    message.payload = entities;
-    message.statusCode = 200;
-    this.node.send(message);
-  }
-};
-
 const validateConfig = function (msg, config) {
   const items = [
     'atContext',
@@ -239,6 +216,29 @@ const createParam = function (msg, config, brokerConfig) {
     },
     out: function (entities) {
       this.entities = this.entities.concat(entities);
+    }
+  };
+
+  const nobuffering = {
+    node: null,
+    msg: null,
+    open: function (node, msg) {
+      this.node = node;
+      this.msg = msg;
+      return this;
+    },
+    send: function (entities) {
+      const message = Object.assign({}, this.msg);
+      message.payload = entities;
+      message.statusCode = 200;
+      this.node.send(message);
+    },
+    close: function () {},
+    out: function (entities) {
+      const message = Object.assign({}, this.msg);
+      message.payload = entities;
+      message.statusCode = 200;
+      this.node.send(message);
     }
   };
 

--- a/src/nodes/NGSI-LD/entities/entities.js
+++ b/src/nodes/NGSI-LD/entities/entities.js
@@ -102,29 +102,6 @@ const nobuffering = {
   }
 };
 
-const buffering = {
-  node: null,
-  msg: null,
-  entities: [],
-  open: function (node, msg) {
-    this.node = node;
-    this.msg = msg;
-    this.entities = [];
-    return this;
-  },
-  send: function (entities) {
-    this.entities = this.entities.concat(entities);
-  },
-  close: function () {
-    this.msg.payload = this.entities;
-    this.msg.statusCode = 200;
-    this.node.send(this.msg);
-  },
-  out: function (entities) {
-    this.entities = this.entities.concat(entities);
-  }
-};
-
 const validateConfig = function (msg, config) {
   const items = [
     'atContext',
@@ -241,6 +218,29 @@ const createParam = function (msg, config, brokerConfig) {
   if (!validateConfig(msg, param.config)) {
     return null;
   }
+
+  const buffering = {
+    node: null,
+    msg: null,
+    entities: [],
+    open: function (node, msg) {
+      this.node = node;
+      this.msg = msg;
+      this.entities = [];
+      return this;
+    },
+    send: function (entities) {
+      this.entities = this.entities.concat(entities);
+    },
+    close: function () {
+      this.msg.payload = this.entities;
+      this.msg.statusCode = 200;
+      this.node.send(this.msg);
+    },
+    out: function (entities) {
+      this.entities = this.entities.concat(entities);
+    }
+  };
 
   param.buffer = param.config.buffering ? buffering.open(this, msg) : nobuffering.open(this, msg);
 

--- a/test/unit/entities_spec.js
+++ b/test/unit/entities_spec.js
@@ -62,6 +62,29 @@ const buffering = {
   }
 };
 
+const nobuffering = {
+  node: null,
+  msg: null,
+  open: function (node, msg) {
+    this.node = node;
+    this.msg = msg;
+    return this;
+  },
+  send: function (entities) {
+    const message = Object.assign({}, this.msg);
+    message.payload = entities;
+    message.statusCode = 200;
+    this.node.send(message);
+  },
+  close: function () {},
+  out: function (entities) {
+    const message = Object.assign({}, this.msg);
+    message.payload = entities;
+    message.statusCode = 200;
+    this.node.send(message);
+  }
+};
+
 describe('entities.js', () => {
   describe('getEntities', () => {
     afterEach(() => {
@@ -104,7 +127,6 @@ describe('entities.js', () => {
       });
 
       const getEntities = entitiesNode.__get__('getEntities');
-      const nobuffering = entitiesNode.__get__('nobuffering');
 
       let actual;
       const param = {
@@ -277,7 +299,6 @@ describe('entities.js', () => {
       });
 
       const getEntities = entitiesNode.__get__('getEntities');
-      const nobuffering = entitiesNode.__get__('nobuffering');
 
       let actual;
       const param = {
@@ -316,7 +337,6 @@ describe('entities.js', () => {
       });
 
       const getEntities = entitiesNode.__get__('getEntities');
-      const nobuffering = entitiesNode.__get__('nobuffering');
 
       let actual;
       const param = {
@@ -353,7 +373,6 @@ describe('entities.js', () => {
         buildParams: () => new URLSearchParams()
       });
       const getEntities = entitiesNode.__get__('getEntities');
-      const nobuffering = entitiesNode.__get__('nobuffering');
 
       const param = {
         host: 'http://orion-ld:1026',
@@ -399,7 +418,6 @@ describe('entities.js', () => {
         decodeNGSI: (data) => data
       });
       const getEntities = entitiesNode.__get__('getEntities');
-      const nobuffering = entitiesNode.__get__('nobuffering');
 
       const param = {
         host: 'http://orion-ld:1026',
@@ -440,7 +458,6 @@ describe('entities.js', () => {
         decodeNGSI: (data) => data
       });
       const getEntities = entitiesNode.__get__('getEntities');
-      const nobuffering = entitiesNode.__get__('nobuffering');
 
       const param = {
         host: 'http://orion-ld:1026',
@@ -474,8 +491,46 @@ describe('entities.js', () => {
     });
   });
   describe('nobuffering', () => {
+    let nobuffering;
+
+    before(() => {
+      // Create a param
+      const createParam = entitiesNode.__get__('createParam');
+      const msg = { payload: { idPattern: '.*' } };
+      const config = {
+        representation: 'normalized',
+        entityId: '',
+        entityType: '',
+        idPattern: '',
+        attrs: '',
+        sysAttrs: 'false',
+        query: '',
+        csf: '',
+        georel: '',
+        geometry: '',
+        coordinates: '',
+        geoproperty: '',
+        geometryProperty: '',
+        lang: '',
+        accept: 'application/ld+json',
+        atContext: '',
+        buffering: 'off'
+      };
+      const brokerConfig = {
+        apiEndpoint: 'http://orion-ld:1026',
+        mintaka: '',
+        getToken: () => {},
+        tenant: 'openiot',
+        atContext: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld'
+      };
+
+      const node = { msg: '' };
+      const param = createParam.call(node, msg, config, brokerConfig);
+
+      nobuffering = param.buffer;
+    });
+
     it('should have a entity', () => {
-      const nobuffering = entitiesNode.__get__('nobuffering');
       const errmsg = {};
       const actual = [];
 
@@ -493,7 +548,6 @@ describe('entities.js', () => {
       assert.deepEqual(actual, [{ payload: [{ id: 'E1', type: 'T' }], statusCode: 200 }]);
     });
     it('should have entities', () => {
-      const nobuffering = entitiesNode.__get__('nobuffering');
       const errmsg = {};
       const actual = [];
 
@@ -515,7 +569,6 @@ describe('entities.js', () => {
       ]);
     });
     it('should be empty', () => {
-      const nobuffering = entitiesNode.__get__('nobuffering');
       const errmsg = {};
       const actual = [];
 
@@ -532,7 +585,6 @@ describe('entities.js', () => {
       assert.deepEqual(actual, []);
     });
     it('should have a entity', () => {
-      const nobuffering = entitiesNode.__get__('nobuffering');
       const errmsg = {};
       const actual = [];
 
@@ -550,7 +602,47 @@ describe('entities.js', () => {
       assert.deepEqual(actual, [{ payload: [{ id: 'E1', type: 'T' }], statusCode: 200 }]);
     });
   });
+
   describe('buffering', () => {
+    let buffering;
+
+    before(() => {
+      // Create a param
+      const createParam = entitiesNode.__get__('createParam');
+      const msg = { payload: { idPattern: '.*' } };
+      const config = {
+        representation: 'normalized',
+        entityId: '',
+        entityType: '',
+        idPattern: '',
+        attrs: '',
+        sysAttrs: 'false',
+        query: '',
+        csf: '',
+        georel: '',
+        geometry: '',
+        coordinates: '',
+        geoproperty: '',
+        geometryProperty: '',
+        lang: '',
+        accept: 'application/ld+json',
+        atContext: '',
+        buffering: 'on'
+      };
+      const brokerConfig = {
+        apiEndpoint: 'http://orion-ld:1026',
+        mintaka: '',
+        getToken: () => {},
+        tenant: 'openiot',
+        atContext: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld'
+      };
+
+      const node = { msg: '' };
+      const param = createParam.call(node, msg, config, brokerConfig);
+
+      buffering = param.buffer;
+    });
+
     it('should have a entity', () => {
       const errmsg = {};
       const actual = [];
@@ -1236,7 +1328,7 @@ describe('entities.js', () => {
         assert.notEqual(param1, param2);
       });
 
-      it('should create a buffering object that allows opening and closing', () => {
+      it('should create a nobuffering object', () => {
         const createParam = entitiesNode.__get__('createParam');
         const msg = { payload: { idPattern: '.*' } };
         const config = {
@@ -1256,7 +1348,7 @@ describe('entities.js', () => {
           lang: '',
           accept: 'application/ld+json',
           atContext: '',
-          buffering: 'on'
+          buffering: 'off'
         };
         const brokerConfig = {
           apiEndpoint: 'http://orion-ld:1026',
@@ -1266,26 +1358,12 @@ describe('entities.js', () => {
           atContext: 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld'
         };
 
-        let outData;
+        const node = { msg: '' };
+        const param1 = createParam.call(node, msg, config, brokerConfig);
+        const param2 = createParam.call(node, msg, config, brokerConfig);
 
-        const node = { msg: '', send: (data) => { outData = data; } };
-        const param = createParam.call(node, msg, config, brokerConfig);
-
-        const buffering = param.buffer;
-        buffering.open(
-          node,
-          { payload: null }
-        );
-
-        buffering.send([{ id: 'E1', type: 'T' }]);
-        buffering.out([{ id: 'E2', type: 'T' }]);
-
-        buffering.close();
-
-        assert.deepEqual(outData, {
-          payload: [{ id: 'E1', type: 'T' }, { id: 'E2', type: 'T' }],
-          statusCode: 200
-        });
+        // Check that params are not the same instance
+        assert.notEqual(param1, param2);
       });
     });
   });


### PR DESCRIPTION
## Proposed changes

The `entities` node uses a shared buffer when buffering is enabled, which leads to nodes returning entities that were not requested and others not returning when multiple requests are processed at the same time.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.
-   [ ] Maintain repository

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/lets-fiware/node-red-contrib-NGSI-LD/blob/main/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://github.com/lets-fiware/node-red-contrib-NGSI-LD/blob/main/node-red-contrib-NGSI-LD-individual-cla.pdf)
-   [x] I have updated the change log (CHANGELOG.md)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate) (not needed)
-   [x] Any dependent changes have been merged and published in downstream modules (none)

## Further comments

This issue has been detected after using these nodes in a production environment with many requests happening at the same time, which lead to the described problem.
